### PR TITLE
Update to Laravel 10 and remove references that break in non-standard Laravel apps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0"
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0"
     },
     "config": {
         "sort-packages": true

--- a/src/Controllers/PlaywrightController.php
+++ b/src/Controllers/PlaywrightController.php
@@ -7,13 +7,6 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Illuminate\Support\Arr;
-use function App\Http\Controllers\app;
-use function App\Http\Controllers\auth;
-use function App\Http\Controllers\collect;
-use function App\Http\Controllers\config;
-use function App\Http\Controllers\csrf_token;
-use function App\Http\Controllers\response;
-use function App\Http\Controllers\tap;
 
 class PlaywrightController
 {


### PR DESCRIPTION
The reason I have removed App\Http\Controllers is because this is dependent on the user's project setup - in my case I didn't have my base controller in the App\Http\Controllers namespace.